### PR TITLE
[BUGFIX] - {IMAGE} 클라이언트에서 결과 안 보이는 버그 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,10 +49,6 @@ dependencies {
     // webflux
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
-    // https://mvnrepository.com/artifact/commons-io/commons-io
-    implementation 'commons-io:commons-io:2.11.0'
-
-
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,10 @@ dependencies {
     // webflux
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+    // https://mvnrepository.com/artifact/commons-io/commons-io
+    implementation 'commons-io:commons-io:2.11.0'
+
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/loveloveshot/configuration/WebClientConfig.java
+++ b/src/main/java/com/loveloveshot/configuration/WebClientConfig.java
@@ -1,0 +1,19 @@
+package com.loveloveshot.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+    @Primary
+    @Bean
+    WebClient.Builder webClient() {
+        return WebClient.builder()
+                .exchangeStrategies(ExchangeStrategies.builder()
+                        .codecs(configurer ->
+                                configurer.defaultCodecs().maxInMemorySize(-1)).build());
+    }
+}

--- a/src/main/java/com/loveloveshot/image/command/application/controller/ImageCommandController.java
+++ b/src/main/java/com/loveloveshot/image/command/application/controller/ImageCommandController.java
@@ -5,23 +5,26 @@ import com.loveloveshot.image.command.application.dto.SingleImageRequest;
 import com.loveloveshot.image.command.application.service.ImageCommandService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
+@CrossOrigin(origins = {"http://localhost:3000"})
 public class ImageCommandController {
 
     private final ImageCommandService imageCommandService;
 
-    @PostMapping("/singleImage") // 필기. RequestParam에 name값을 지정해주지 않으면 디폴트로 변수명을 key값으로 가짐.
+    @PostMapping(value = "/singleImage")
+    // 필기. RequestParam에 name값을 지정해주지 않으면 디폴트로 변수명을 key값으로 가짐.
     public ResponseEntity<ApiResponse> uploadSingleImage(@RequestParam MultipartFile maleSingleImage,
                                                          @RequestParam MultipartFile femaleSingleImage,
-                                                         SingleImageRequest singleImageDTO) {
+                                                         SingleImageRequest singleImageDTO) throws IOException {
+        System.out.println("maleSingleImage = " + maleSingleImage);
+        System.out.println("femaleSingleImage = " + femaleSingleImage);
 
         singleImageDTO.setMaleSingleImage(maleSingleImage);
         singleImageDTO.setFemaleSingleImage(femaleSingleImage);

--- a/src/main/java/com/loveloveshot/image/command/application/controller/ImageCommandController.java
+++ b/src/main/java/com/loveloveshot/image/command/application/controller/ImageCommandController.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
-@CrossOrigin(origins = {"http://localhost:3000"})
+@CrossOrigin(origins = {"*"})
 public class ImageCommandController {
 
     private final ImageCommandService imageCommandService;
@@ -23,9 +23,6 @@ public class ImageCommandController {
     public ResponseEntity<ApiResponse> uploadSingleImage(@RequestParam MultipartFile maleSingleImage,
                                                          @RequestParam MultipartFile femaleSingleImage,
                                                          SingleImageRequest singleImageDTO) throws IOException {
-        System.out.println("maleSingleImage = " + maleSingleImage);
-        System.out.println("femaleSingleImage = " + femaleSingleImage);
-
         singleImageDTO.setMaleSingleImage(maleSingleImage);
         singleImageDTO.setFemaleSingleImage(femaleSingleImage);
 

--- a/src/main/java/com/loveloveshot/image/command/application/dto/ImageResponse.java
+++ b/src/main/java/com/loveloveshot/image/command/application/dto/ImageResponse.java
@@ -3,7 +3,6 @@ package com.loveloveshot.image.command.application.dto;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.io.Serializable;
 
@@ -11,5 +10,6 @@ import java.io.Serializable;
 @RequiredArgsConstructor
 @NoArgsConstructor(force = true)
 public class ImageResponse implements Serializable {
-    private final MultipartFile aiImage;
+    //    private final File aiImage;
+    private final String aiImage;
 }

--- a/src/main/java/com/loveloveshot/image/command/application/dto/ImageResponse.java
+++ b/src/main/java/com/loveloveshot/image/command/application/dto/ImageResponse.java
@@ -10,8 +10,6 @@ import java.io.Serializable;
 @Getter
 @RequiredArgsConstructor
 @NoArgsConstructor(force = true)
-public class AiImageResponse implements Serializable {
-
+public class ImageResponse implements Serializable {
     private final MultipartFile aiImage;
-
 }

--- a/src/main/java/com/loveloveshot/image/command/application/service/ImageCommandService.java
+++ b/src/main/java/com/loveloveshot/image/command/application/service/ImageCommandService.java
@@ -1,12 +1,12 @@
 package com.loveloveshot.image.command.application.service;
 
+import com.loveloveshot.image.command.application.dto.ImageResponse;
 import com.loveloveshot.image.command.application.dto.SingleImageRequest;
 import com.loveloveshot.image.command.domain.repository.ImageCommandRepository;
 import com.loveloveshot.image.command.domain.service.ImageCommandDomainService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.io.File;
 import java.io.IOException;
 
 @Service
@@ -17,9 +17,9 @@ public class ImageCommandService {
     private final ImageCommandRepository imageCommandRepository;
 
 
-    public File createAISingleImage(Long userNo, SingleImageRequest singleImageDTO) throws IOException {
+    public ImageResponse createAISingleImage(Long userNo, SingleImageRequest singleImageDTO) throws IOException {
 
-        File aiImageDTO = imageCommandDomainService.getAISingleImage(singleImageDTO);
+        ImageResponse aiImageDTO = imageCommandDomainService.getAISingleImage(singleImageDTO);
 
 //        String filePath = "C:\\AIImages/";
 //

--- a/src/main/java/com/loveloveshot/image/command/application/service/ImageCommandService.java
+++ b/src/main/java/com/loveloveshot/image/command/application/service/ImageCommandService.java
@@ -1,9 +1,6 @@
 package com.loveloveshot.image.command.application.service;
 
-import com.loveloveshot.image.command.application.dto.AiImageResponse;
 import com.loveloveshot.image.command.application.dto.SingleImageRequest;
-import com.loveloveshot.image.command.domain.aggregate.entity.Image;
-import com.loveloveshot.image.command.domain.aggregate.vo.UserVO;
 import com.loveloveshot.image.command.domain.repository.ImageCommandRepository;
 import com.loveloveshot.image.command.domain.service.ImageCommandDomainService;
 import lombok.RequiredArgsConstructor;
@@ -11,7 +8,6 @@ import org.springframework.stereotype.Service;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -21,36 +17,36 @@ public class ImageCommandService {
     private final ImageCommandRepository imageCommandRepository;
 
 
-    public AiImageResponse createAISingleImage(Long userNo, SingleImageRequest singleImageDTO) {
+    public File createAISingleImage(Long userNo, SingleImageRequest singleImageDTO) throws IOException {
 
-        AiImageResponse aiImageDTO = imageCommandDomainService.getAISingleImage(singleImageDTO);
+        File aiImageDTO = imageCommandDomainService.getAISingleImage(singleImageDTO);
 
-        String filePath = "C:\\AIImages/";
-
-        File dir = new File(filePath);
-        if (!dir.exists()) {
-            dir.mkdirs();   //폴더 없을 시 자동으로 하위폴더 생성
-        }
-
-        String originFileName = aiImageDTO.getAiImage().getOriginalFilename();  //원본 파일 이름
-        String ext = originFileName.substring(originFileName.lastIndexOf(".") + 1); //파일 확장자
-        String savedName = UUID.randomUUID().toString().replaceAll("-", "") + "." + ext; //저장되는 이름
-
-        try {
-            aiImageDTO.getAiImage().transferTo(new File(filePath + savedName));
-
-            Image image = Image.builder()
-                    .originImageName(originFileName)
-                    .savedImageName(savedName)
-                    .imagePath(filePath)
-                    .userVO(new UserVO(userNo))
-                    .build();
-
-            imageCommandRepository.save(image);
-
-        } catch (IOException e) {
-            new File(filePath + savedName).delete();  //업로드 후 DB저장 중 오류났을 때 업로드된 이미지 삭제해줌
-        }
+//        String filePath = "C:\\AIImages/";
+//
+//        File dir = new File(filePath);
+//        if (!dir.exists()) {
+//            dir.mkdirs();   //폴더 없을 시 자동으로 하위폴더 생성
+//        }
+//
+//        String originFileName = aiImageDTO.getAiImage().getOriginalFilename();  //원본 파일 이름
+//        String ext = originFileName.substring(originFileName.lastIndexOf(".") + 1); //파일 확장자
+//        String savedName = UUID.randomUUID().toString().replaceAll("-", "") + "." + ext; //저장되는 이름
+//
+//        try {
+//            aiImageDTO.getAiImage().transferTo(new File(filePath + savedName));
+//
+//            Image image = Image.builder()
+//                    .originImageName(originFileName)
+//                    .savedImageName(savedName)
+//                    .imagePath(filePath)
+//                    .userVO(new UserVO(userNo))
+//                    .build();
+//
+//            imageCommandRepository.save(image);
+//
+//        } catch (IOException e) {
+//            new File(filePath + savedName).delete();  //업로드 후 DB저장 중 오류났을 때 업로드된 이미지 삭제해줌
+//        }
 
         return aiImageDTO;
     }

--- a/src/main/java/com/loveloveshot/image/command/domain/service/ImageCommandDomainService.java
+++ b/src/main/java/com/loveloveshot/image/command/domain/service/ImageCommandDomainService.java
@@ -1,15 +1,15 @@
 package com.loveloveshot.image.command.domain.service;
 
 import com.loveloveshot.common.annotation.DomainService;
+import com.loveloveshot.image.command.application.dto.ImageResponse;
 import com.loveloveshot.image.command.application.dto.SingleImageRequest;
 
-import java.io.File;
 import java.io.IOException;
 
 @DomainService
 public interface ImageCommandDomainService {
 
-    File getAISingleImage(SingleImageRequest singleImageDTO) throws IOException;
+    ImageResponse getAISingleImage(SingleImageRequest singleImageDTO) throws IOException;
 
 //    void getAIImageList(ImageListRequestDTO imageListDTO);
 }

--- a/src/main/java/com/loveloveshot/image/command/domain/service/ImageCommandDomainService.java
+++ b/src/main/java/com/loveloveshot/image/command/domain/service/ImageCommandDomainService.java
@@ -1,13 +1,15 @@
 package com.loveloveshot.image.command.domain.service;
 
 import com.loveloveshot.common.annotation.DomainService;
-import com.loveloveshot.image.command.application.dto.AiImageResponse;
 import com.loveloveshot.image.command.application.dto.SingleImageRequest;
+
+import java.io.File;
+import java.io.IOException;
 
 @DomainService
 public interface ImageCommandDomainService {
 
-    AiImageResponse getAISingleImage(SingleImageRequest singleImageDTO);
+    File getAISingleImage(SingleImageRequest singleImageDTO) throws IOException;
 
 //    void getAIImageList(ImageListRequestDTO imageListDTO);
 }

--- a/src/main/java/com/loveloveshot/image/command/infrastructure/service/ImageCommandInfraService.java
+++ b/src/main/java/com/loveloveshot/image/command/infrastructure/service/ImageCommandInfraService.java
@@ -1,20 +1,31 @@
 package com.loveloveshot.image.command.infrastructure.service;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
 import com.loveloveshot.common.annotation.InfraService;
-import com.loveloveshot.image.command.application.dto.AiImageResponse;
 import com.loveloveshot.image.command.application.dto.SingleImageRequest;
 import com.loveloveshot.image.command.domain.service.ImageCommandDomainService;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.MultipartBodyBuilder;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.util.Base64;
+
 @InfraService
 public class ImageCommandInfraService implements ImageCommandDomainService {
-    final String REQUEST_URL = "http://192.168.0.40:5001"; // AI 이미지 생성 API URL
+    final String REQUEST_URL = "http://192.168.0.241:5001"; // AI 이미지 생성 API URL
 
     @Override
-    public AiImageResponse getAISingleImage(SingleImageRequest singleImageDTO) {
+    public File getAISingleImage(SingleImageRequest singleImageDTO) throws IOException {
 
 //      HttpURLConnection 방식
 //        try {
@@ -41,18 +52,50 @@ public class ImageCommandInfraService implements ImageCommandDomainService {
         WebClient webClient = WebClient.builder().baseUrl(REQUEST_URL).build();
 
         MultipartBodyBuilder formData = new MultipartBodyBuilder();
-        formData.part("imgFile", singleImageDTO.getMaleSingleImage());
-        formData.part("imgFile", singleImageDTO.getFemaleSingleImage());
+        formData.part("imgFile", singleImageDTO.getMaleSingleImage().getResource());
+        formData.part("imgFile", singleImageDTO.getFemaleSingleImage().getResource());
 
-        AiImageResponse response = webClient.post()
-                .uri("/") // baseUrl 이후 uri
+        MultiValueMap<String, MultipartFile> form = new LinkedMultiValueMap<>();
+        form.add("maleImage", singleImageDTO.getMaleSingleImage());
+        form.add("femaleImage", singleImageDTO.getFemaleSingleImage());
+
+        String response = webClient.post()
+                .uri("/main/standard") // baseUrl 이후 uri
+                .accept(MediaType.MULTIPART_FORM_DATA)
                 .contentType(MediaType.MULTIPART_FORM_DATA) // 보내는 자원의 형식(header에 담김)
+//                .body(BodyInserters.fromMultipartData(form))
                 .body(BodyInserters.fromMultipartData(formData.build())) // 요청 body
                 .retrieve() // ResponseEntity를 받아 디코딩
-                .bodyToMono(AiImageResponse.class) // 0~1개의 결과 리턴
-                .block(); // 응답 대기(blocking)
-        System.out.println("response = " + response);
-        return response;
+                .bodyToMono(String.class).block(); // 0~1개의 결과 리턴
+//        System.out.println("response = " + response);
+
+        JsonElement element = JsonParser.parseString(response);
+        String fileData = element.getAsJsonObject().get("file_data").getAsString();
+//        System.out.println("fileData = " + fileData);
+
+        // 이것은 예시로 사용한 Base64 인코딩된 이미지 문자열입니다.
+        // 실제 애플리케이션에서는 서버 또는 다른 소스로부터 이 값을 받아옵니다.
+
+        // Base64 문자열을 바이트 배열로 변환
+        byte[] imageBytes = Base64.getDecoder().decode(fileData);
+
+        // 바이트 배열을 BufferedImage 객체로 변환
+        try (ByteArrayInputStream bis = new ByteArrayInputStream(imageBytes)) {
+            BufferedImage image = ImageIO.read(bis);
+
+            // BufferedImage 객체를 이미지 파일로 저장
+            ImageIO.write(image, "png", new File("output.png"));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        System.out.println("imageBytes = " + imageBytes);
+
+//        MultipartFile multipartFile =
+//        System.out.println("response.block() = " + response.block().getAiImage());
+//        System.out.println("response.subscribe() = " + response.collectList().subscribe());
+//        System.out.println("response = " + response.block().getAiImage());
+//        System.out.println("response222 = " + response.block().getAiImage().get(0));
+        return new File("C:\\Lecture\\01_java\\local-repo\\loveloveshot\\output.png");
     }
 
 //    @Override


### PR DESCRIPTION
# ✨(#이슈번호) 제목
* closed #30 

# ✏️내용
결과 창에서 결과 바로 안 보여지는 버그 존재
-> 원래 AI 이미지를 resource/static 하위에 저장 시키고 리액트에 해당 상대 경로를 리턴 해줬음
-> 이미지 저장이 톰캣 서버에 우선 저장되기 때문에 스프링 서버에 저장된 경로를 리액트에서 못 읽어옴
-> src/main 하위에 webapp 폴더를 만들면 여기에 저장된 이미지는 우선적으로 읽을 수 있다는 정보를 얻음 
-> webapp 폴더를 만들고 AI 이미지를 여기에 저장 시킨 뒤 상대 경로를 리턴, 리액트에서 서비스 서버에 저장된 AI 이미지를 읽도록 함

# 📸스크린샷

# 🎁참고사항
